### PR TITLE
Fix update_config method

### DIFF
--- a/ckanext/asset_storage/plugin.py
+++ b/ckanext/asset_storage/plugin.py
@@ -1,9 +1,8 @@
-import six
-
 from ast import literal_eval
 
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
+import six
 
 from ckanext.asset_storage import uploader
 from ckanext.asset_storage.blueprints import blueprint

--- a/ckanext/asset_storage/plugin.py
+++ b/ckanext/asset_storage/plugin.py
@@ -22,8 +22,10 @@ class AssetStoragePlugin(plugins.SingletonPlugin):
         backend_config = config.get(uploader.CONF_BACKEND_CONFIG)
         if not backend_config:
             backend_config = {}
-        else:
+
+        if type(backend_config) == str:
             backend_config = literal_eval(backend_config)
+
         config[uploader.CONF_BACKEND_CONFIG] = backend_config
 
     # IBlueprint

--- a/ckanext/asset_storage/plugin.py
+++ b/ckanext/asset_storage/plugin.py
@@ -1,3 +1,5 @@
+import six
+
 from ast import literal_eval
 
 import ckan.plugins as plugins
@@ -22,8 +24,7 @@ class AssetStoragePlugin(plugins.SingletonPlugin):
         backend_config = config.get(uploader.CONF_BACKEND_CONFIG)
         if not backend_config:
             backend_config = {}
-
-        if type(backend_config) == str:
+        elif isinstance(backend_config, six.string_types):
             backend_config = literal_eval(backend_config)
 
         config[uploader.CONF_BACKEND_CONFIG] = backend_config


### PR DESCRIPTION
CKAN main app loads the `ckanext.asset_storage.backend_config` as string but when executing workers, they load the config as a dictionary. 

Currently, workers fails to execute jobs with the following error:
```
2021-02-25 23:03:43,979 INFO  [rq.worker] [MainThread] ckan:default:default: ckanext.xloader.jobs.xloader_data_into_datastore({'result_url': u'<removed>', 'api_key': u'<removed>', 'job_type': 'xloader_to_datastore', 'metadata': {'original_url': '<removed>', 'ckan_url': u'<removed>', 'set_url_type': False, 'task_created': '2021-02-25 23:03:43.962411', 'ignore_hash': False}}) (bc165ac5-94f1-42a0-b614-6d0ebb4c6b06)
Traceback (most recent call last):
  File "/usr/local/bin/ckan-paster", line 8, in <module>
    sys.exit(run())
  File "/usr/local/lib/python2.7/dist-packages/paste/script/command.py", line 102, in run
    invoke(command, command_name, options, args[1:])
  File "/usr/local/lib/python2.7/dist-packages/paste/script/command.py", line 141, in invoke
    exit_code = runner.run(args)
  File "/usr/local/lib/python2.7/dist-packages/paste/script/command.py", line 236, in run
    result = self.command()
  File "/usr/lib/ckan/src/ckan/ckan/lib/cli.py", line 2581, in command
    self.worker()
  File "/usr/lib/ckan/src/ckan/ckan/lib/cli.py", line 2597, in worker
    Worker(self.args).work(burst=self.options.burst)
  File "/usr/local/lib/python2.7/dist-packages/rq/worker.py", line 450, in work
    self.execute_job(job, queue)
  File "/usr/lib/ckan/src/ckan/ckan/lib/jobs.py", line 276, in execute_job
    result = super(Worker, self).execute_job(job, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/rq/worker.py", line 515, in execute_job
    self.main_work_horse(job, queue)
  File "/usr/lib/ckan/src/ckan/ckan/lib/jobs.py", line 295, in main_work_horse
    load_environment(config[u'global_conf'], config)
  File "/usr/lib/ckan/src/ckan/ckan/config/environment.py", line 116, in load_environment
    p.load_all()
  File "/usr/lib/ckan/src/ckan/ckan/plugins/core.py", line 140, in load_all
    load(*plugins)
  File "/usr/lib/ckan/src/ckan/ckan/plugins/core.py", line 168, in load
    plugins_update()
  File "/usr/lib/ckan/src/ckan/ckan/plugins/core.py", line 122, in plugins_update
    environment.update_config()
  File "/usr/lib/ckan/src/ckan/ckan/config/environment.py", line 168, in update_config
    plugin.update_config(config)
  File "/usr/local/lib/python2.7/dist-packages/ckanext/asset_storage/plugin.py", line 26, in update_config
    backend_config = literal_eval(backend_config)
  File "/usr/lib/python2.7/ast.py", line 80, in literal_eval
    return _convert(node_or_string)
  File "/usr/lib/python2.7/ast.py", line 79, in _convert
    raise ValueError('malformed string')
ValueError: malformed string
```

The current is how it looks when executing a job:

```
> /home/pdelboca/Repos/ckanext-asset-storage/ckanext/asset_storage/plugin.py(27)update_config()
     22         backend_config = config.get(uploader.CONF_BACKEND_CONFIG)
     23         if not backend_config:
     24             backend_config = {}
     25         else:
     26             import ipdb; ipdb.set_trace(context=10)
---> 27             backend_config = literal_eval(backend_config)
     28 
     29         config[uploader.CONF_BACKEND_CONFIG] = backend_config
     30 
     31     # IBlueprint

ipdb> type(backend_config)
<type 'dict'>
ipdb> literal_eval(backend_config)
*** ValueError: malformed string
```

This may be a buggy behavior in CKAN that may worth exploring and fixing upstream.