### PR TITLE
Add filename property

### DIFF
--- a/ckanext/asset_storage/tests/test_uploader.py
+++ b/ckanext/asset_storage/tests/test_uploader.py
@@ -110,4 +110,4 @@ def test_uploader_property():
                  'file': FieldStorage(fp=BytesIO(b'hello'),
                                       headers={"content-disposition": 'form-data; name="file"; filename="foo.png"'})}
     up.update_data_dict(data_dict, 'url', 'file', 'clear')
-    assert up.filename == 'foo.png'
+    assert up.filename.endswith('-foo.png')

--- a/ckanext/asset_storage/tests/test_uploader.py
+++ b/ckanext/asset_storage/tests/test_uploader.py
@@ -104,5 +104,10 @@ def test_uploader_update_data_dict_existing_file_cgi():
 
 def test_uploader_property():
     backend = uploader.get_configured_storage()
-    up = uploader.AssetUploader(backend, 'group', 'original.png')
-    assert up.filename == 'original.png'
+    up = uploader.AssetUploader(backend, 'group', 'bar.png')
+    data_dict = {'url': 'foo.png',
+                 'clear': '',
+                 'file': FieldStorage(fp=BytesIO(b'hello'),
+                                      headers={"content-disposition": 'form-data; name="file"; filename="foo.png"'})}
+    up.update_data_dict(data_dict, 'url', 'file', 'clear')
+    assert up.filename == 'foo.png'

--- a/ckanext/asset_storage/tests/test_uploader.py
+++ b/ckanext/asset_storage/tests/test_uploader.py
@@ -100,3 +100,9 @@ def test_uploader_update_data_dict_existing_file_cgi():
     up.update_data_dict(data_dict, 'url', 'file', 'clear')
     assert data_dict['url'].startswith('http://localhost:5000/uploads/group/')
     assert data_dict['url'].endswith('-foo.png')
+
+
+def test_uploader_property():
+    backend = uploader.get_configured_storage()
+    up = uploader.AssetUploader(backend, 'group', 'original.png')
+    assert up.filename == 'original.png'

--- a/ckanext/asset_storage/uploader.py
+++ b/ckanext/asset_storage/uploader.py
@@ -63,6 +63,10 @@ class AssetUploader(object):
         if old_filename:
             self._old_filename = self._parse_old_uri(old_filename)
 
+    @property
+    def filename(self):
+        return self._filename
+
     def update_data_dict(self, data_dict, url_field, file_field, clear_field):
         """Manipulate data from the data_dict. This needs to be called before it
         reaches any validators.


### PR DESCRIPTION
Both CKAN and cloudstorage uploaders expose filename as a property so extensions can access to it.

I'm adding a property so we have better compatibility across extensions.